### PR TITLE
Trigger volumechange event

### DIFF
--- a/videojs.persistvolume.js
+++ b/videojs.persistvolume.js
@@ -84,7 +84,7 @@
 
     var key = settings.namespace + '-' + 'volume';
     var muteKey = settings.namespace + '-' + 'mute';
-    
+
     player.on("volumechange", function() {
       setStorageItem(key, player.volume());
       setStorageItem(muteKey, player.muted());
@@ -94,11 +94,13 @@
     if(persistedVolume !== null){
       player.volume(persistedVolume);
     }
-    
+
     var persistedMute = getStorageItem(muteKey);
     if(persistedMute !== null){
       player.muted('true' === persistedMute);
     }
+
+    this.player_.trigger('volumechange');
   };
 
   vjs.plugin("persistvolume", volumePersister);


### PR DESCRIPTION
In a case where video player is created without a page reload, player volume bar is not updated if volumechange event is not triggered.
