### PR TITLE
Prefer vjs.registerPlugin over vjs.plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-videojs-persistvolume
-========================
+# videojs-persistvolume
 
 A plugin for Video.js that saves user's volume setting using [localStorage](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Storage#localStorage), but falls back to cookies if necessary.
 
-###Usage
+### Usage
 Include the plugin:
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "name": "videojs-persistvolume",
     "main": "videojs.persistvolume.js",
-    "version": "0.1.2"
+    "version": "0.1.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "videojs-persistvolume",
+    "main": "videojs.persistvolume.js",
+    "version": "0.1.2"
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,11 @@
 {
     "name": "videojs-persistvolume",
     "main": "videojs.persistvolume.js",
-    "version": "0.1.3"
+    "version": "0.1.3p1",
+    "license": "MIT",
+    "homepage": "https://github.com/jbboehr/videojs-persistvolume",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/jbboehr/videojs-persistvolume.git"
+    }
 }

--- a/test/example.html
+++ b/test/example.html
@@ -19,9 +19,9 @@
   <video id="vid1" class="video-js vjs-default-skin" autoplay controls preload="auto"
       poster="http://video-js.zencoder.com/oceans-clip.png"
       data-setup='{}'>
-    <source src="http://video-js.zencoder.com/oceans-clip.mp4" type='video/mp4'>
-    <source src="http://video-js.zencoder.com/oceans-clip.webm" type='video/webm'>
-    <source src="http://video-js.zencoder.com/oceans-clip.ogv" type='video/ogg'>
+    <source src="http://vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
+    <source src="http://vjs.zencdn.net/v/oceans.webm" type='video/webm'>
+    <source src="http://vjs.zencdn.net/v/oceans.ogv" type='video/ogg'>
     <p>Video Playback Not Supported</p>
   </video>
 

--- a/videojs.persistvolume.js
+++ b/videojs.persistvolume.js
@@ -120,6 +120,6 @@
     });
   };
 
-  vjs.plugin("persistvolume", volumePersister);
+  vjs[ (vjs.registerPlugin ? 'registerPlugin' : 'plugin') ]("persistvolume", volumePersister);
 
 });

--- a/videojs.persistvolume.js
+++ b/videojs.persistvolume.js
@@ -1,5 +1,5 @@
 "use strict";
-(function(factory){
+(function(factory) {
   /*!
    * Custom Universal Module Definition (UMD)
    *
@@ -107,15 +107,17 @@
       setStorageItem(muteKey, player.muted());
     });
 
-    var persistedVolume = getStorageItem(key);
-    if(persistedVolume !== null){
-      player.volume(persistedVolume);
-    }
+    player.ready(function() {
+      var persistedVolume = getStorageItem(key);
+      if(persistedVolume !== null) {
+        player.volume(persistedVolume);
+      }
 
-    var persistedMute = getStorageItem(muteKey);
-    if(persistedMute !== null){
-      player.muted('true' === persistedMute);
-    }
+      var persistedMute = getStorageItem(muteKey);
+      if(persistedMute !== null) {
+        player.muted('true' === persistedMute);
+      }
+    });
   };
 
   vjs.plugin("persistvolume", volumePersister);

--- a/videojs.persistvolume.js
+++ b/videojs.persistvolume.js
@@ -8,7 +8,7 @@
    * compiler compatible, so string keys are used.
    */
   if (typeof define === 'function' && define['amd']) {
-    define(['./video'], function(vjs){ factory(window, document, vjs) });
+    define(['video.js'], function(vjs){ factory(window, document, vjs) });
   // checking that module is an object too because of umdjs/umd#35
   } else if (typeof exports === 'object' && typeof module === 'object') {
     factory(window, document, require('video.js'));


### PR DESCRIPTION
With the current version of video.js this code produces a warning using the deprecated plugin loading method.

This patch will support both methods.